### PR TITLE
Replace unix mkdir with python makedirs

### DIFF
--- a/train.py
+++ b/train.py
@@ -90,10 +90,7 @@ class args:
     ep_num = 0
     dataset = "MNIST"
 
-try:
-    os.system("mkdir " + args.save_dir)
-except:
-    print("mkdir " + args.save_dir)
+os.makedirs(args.save_dir, exist_ok=True)
 try:
     os.system("cp deepcaps.py " + args.save_dir + "/deepcaps.py")
 except:


### PR DESCRIPTION
The current problem is that 'mkdir` does not create subfolders and throws an error.

This PR replaces the hardcoded `mkdir` with a python internal function which handles creation of  folders OS-independent and without errors.

Fixes #5