### PR TITLE
Use TF 1.13.1 due to bug in Keras 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The current `test error on CIFAR10 = 7.26%`.
 ## Usage
 ### step 1 : Install dependencies
 ```
-conda install -c anaconda tensorflow-gpu
+conda install -c anaconda tensorflow-gpu=1.13.1
 conda install -c anaconda keras-gpu 
 conda install -c conda-forge matplotlib
 conda install -c conda-forge pillow


### PR DESCRIPTION
Upstream ticket:
https://github.com/tensorflow/tensorflow/issues/30728

Fixed in Keras 2.3.0 which is not yet in Anaconda: https://anaconda.org/anaconda/keras-gpu

Fixes #7