### PR TITLE
Use SciPy-1.2 to workaround imresize deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The current `test error on CIFAR10 = 7.26%`.
 ```
 conda install -c anaconda tensorflow-gpu=1.13.1
 conda install -c anaconda keras-gpu 
+conda install -c anaconda scipy=1.2*
 conda install -c conda-forge matplotlib
 conda install -c conda-forge pillow
 ```


### PR DESCRIPTION
imresize has been deprecated as of SciPy 1.3:
https://docs.scipy.org/doc/scipy-1.2.1/reference/generated/scipy.misc.imresize.html

Relates to #9